### PR TITLE
added support for rocket-silo modules and energy usage

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -244,4 +244,13 @@ for _, obj in pairs(data.raw["furnace"]) do
 	if obj.module_slots ~= nil and obj.module_slots > 0 then obj.quality_affects_module_slots = setting("quality_affects_module_slots_furnace") end
 end
 
+if data.raw["rocket-silo"] then
+	for _, obj in pairs(data.raw["rocket-silo"]) do
+	obj.quality_affects_energy_usage = setting("quality_affects_energy_usage_silo")
+	-- This is a temporary fix to prevent polution from being removed by the above setting, will be resolved in Version 2.1 and can be removed
+	if setting("quality_affects_energy_usage_silo") then obj.energy_usage_quality_multiplier = { normal=1 } end
+	if obj.module_slots ~= nil and obj.module_slots > 0 then obj.quality_affects_module_slots = setting("quality_affects_module_slots_silo") end
+	end
+end
+
 data.raw["utility-constants"]["default"].maximum_quality_jump = setting("maximum_quality_jump")

--- a/locale/en/config.cfg
+++ b/locale/en/config.cfg
@@ -52,9 +52,11 @@ transcendent_next_probability=[quality=transcendent] Next Probability
 
 quality_affects_energy_usage_crafting=[virtual-signal=signal-any-quality] [item=assembling-machine-1] Scales energy use
 quality_affects_energy_usage_furnace=[virtual-signal=signal-any-quality] [item=electric-furnace] Scales energy use
+quality_affects_energy_usage_silo=[virtual-signal=signal-any-quality] [item=rocket-silo] Scales energy use
 crafting_machine_energy_usage_reduction=[virtual-signal=signal-any-quality] [item=assembling-machine-1] [item=electric-furnace] Energy use reduction
 quality_affects_module_slots_crafting=[virtual-signal=signal-any-quality] [item=assembling-machine-1] Scales module slots
 quality_affects_module_slots_furnace=[virtual-signal=signal-any-quality] [item=electric-furnace] Scales module slots
+quality_affects_module_slots_silo=[virtual-signal=signal-any-quality] [item=rocket-silo] Scales module slots
 crafting_machine_module_slots_bonus=[virtual-signal=signal-any-quality] [item=assembling-machine-1] [item=electric-furnace] Bonus module multiplier
 crafting_machine_speed_multiplier=[virtual-signal=signal-any-quality] [item=assembling-machine-1] [item=electric-furnace] Speed multiplier
 inserter_speed_multiplier=[virtual-signal=signal-any-quality] [item=inserter] Speed multiplier

--- a/settings.lua
+++ b/settings.lua
@@ -571,6 +571,18 @@ if mods["space-age"] then
 		minimum_value = 0,
 		maximum_value = 1,
 		order = "n6"
+		}, {
+		type = "bool-setting",
+		name = "quality_affects_energy_usage_silo",
+		setting_type = "startup",
+		default_value = false,
+		order = "n7"
+		}, {
+		type = "bool-setting",
+		name = "quality_affects_module_slots_silo",
+		setting_type = "startup",
+		default_value = false,
+		order = "n8"
 	}})
 end
 


### PR DESCRIPTION
this adds module scaling and energy drain to silos

energy drain does not seem to work with the silo, i followed your example from the "assembling-machine" but it stays as 4.0MW maybe have a look

it could be a engine bug, since the silo is a modified "assembling-machine" to my understanding, would be nice to know
